### PR TITLE
Add transaction code for stand-alone program

### DIFF
--- a/zabapgit.tran.xml
+++ b/zabapgit.tran.xml
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_TRAN" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <TSTC>
+    <TCODE>ZGIT</TCODE>
+    <PGMNA>ZABAPGIT_STANDALONE</PGMNA>
+    <DYPNO>1000</DYPNO>
+    <CINFO>gA==</CINFO>
+   </TSTC>
+   <TSTCC>
+    <TCODE>ZGIT</TCODE>
+    <S_WEBGUI>1</S_WEBGUI>
+    <S_WIN32>X</S_WIN32>
+    <S_PLATIN>X</S_PLATIN>
+   </TSTCC>
+   <TSTCT>
+    <SPRSL>E</SPRSL>
+    <TCODE>ZGIT</TCODE>
+    <TTEXT>abapGit</TTEXT>
+   </TSTCT>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
The documentation does not suggest any particular code for the stand-alone version. `ZABAPGIT` is used for the developer version. 

https://docs.abapgit.org/guide-install.html

Adds `ZGIT` transaction code.  

Closes #5